### PR TITLE
Jwt Annotation 구현

### DIFF
--- a/src/main/java/com/devillage/teamproject/config/WebConfig.java
+++ b/src/main/java/com/devillage/teamproject/config/WebConfig.java
@@ -1,12 +1,20 @@
 package com.devillage.teamproject.config;
 
+import com.devillage.teamproject.security.resolver.ResultJwtArgumentResolver;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+    private final ResultJwtArgumentResolver jwtArgumentResolver;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
@@ -20,5 +28,10 @@ public class WebConfig implements WebMvcConfigurer {
                         HttpMethod.PUT.name(),
                         HttpMethod.POST.name()
                 );
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(jwtArgumentResolver);
     }
 }

--- a/src/main/java/com/devillage/teamproject/dto/AuthDto.java
+++ b/src/main/java/com/devillage/teamproject/dto/AuthDto.java
@@ -5,6 +5,7 @@ import lombok.*;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Pattern;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -77,5 +78,15 @@ public class AuthDto {
                     .refreshToken(refreshToken)
                     .build();
         }
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @Builder
+    public static class UserInfo {
+        private String email;
+        private Long id;
+        private List<String> roles;
     }
 }

--- a/src/main/java/com/devillage/teamproject/security/resolver/AccessToken.java
+++ b/src/main/java/com/devillage/teamproject/security/resolver/AccessToken.java
@@ -1,0 +1,12 @@
+package com.devillage.teamproject.security.resolver;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target(PARAMETER)
+@Retention(RUNTIME)
+public @interface AccessToken {
+}

--- a/src/main/java/com/devillage/teamproject/security/resolver/ResultJwtArgumentResolver.java
+++ b/src/main/java/com/devillage/teamproject/security/resolver/ResultJwtArgumentResolver.java
@@ -1,0 +1,54 @@
+package com.devillage.teamproject.security.resolver;
+
+import com.devillage.teamproject.dto.AuthDto;
+import com.devillage.teamproject.exception.BusinessLogicException;
+import com.devillage.teamproject.security.util.JwtTokenUtil;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.List;
+
+import static com.devillage.teamproject.exception.ExceptionCode.MALFORMED_JWT_EXCEPTION;
+import static com.devillage.teamproject.security.util.JwtConstants.*;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ResultJwtArgumentResolver implements HandlerMethodArgumentResolver {
+    private final JwtTokenUtil jwtTokenUtil;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterAnnotation(AccessToken.class) != null;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        log.info("시작");
+        String accessToken = webRequest.getHeader(AUTHORIZATION_HEADER);
+        log.info("accessToken = {}", accessToken);
+
+        if ( accessToken==null ) {
+            throw new BusinessLogicException(MALFORMED_JWT_EXCEPTION);
+        }
+
+        String token = jwtTokenUtil.splitToken(accessToken);
+        Claims claims = jwtTokenUtil.paresAccessToken(token);
+        String email = claims.getSubject();
+        List<String> roles = (List) claims.get(ROLES);
+        Long id = Long.valueOf((Integer)claims.get(SEQUENCE));
+
+        return AuthDto.UserInfo.builder()
+                .id(id)
+                .email(email)
+                .roles(roles)
+                .build();
+    }
+}


### PR DESCRIPTION
이제 토큰 분해 로직을 따로 구현할 필요 없이 컨트롤러에서 바로 유저 정보를 가져올 수 있습니다.