### PR TITLE
Fix : 댓글에 좋아요표시가 반대로 되어있던점 수정

### DIFF
--- a/src/main/java/com/devillage/teamproject/dto/CommentDto.java
+++ b/src/main/java/com/devillage/teamproject/dto/CommentDto.java
@@ -89,11 +89,7 @@ public class CommentDto {
                             .likeCount(0L)
                             .createdAt(comment.getCreatedAt())
                             .lastModifiedAt(comment.getLastModifiedAt())
-                            .isLiked(
-                                    comment.getCommentLikes().stream().map(
-                                            commentLike -> commentLike.getUser().getId()
-                                    ).collect(Collectors.toList()).contains(userId)
-                            )
+                            .isLiked(false)
                             .build() :
                     ResponseWithReComment.builder()
                             .commentId(comment.getId())
@@ -106,7 +102,11 @@ public class CommentDto {
                             .likeCount(comment.getCommentLikes().size())
                             .createdAt(comment.getCreatedAt())
                             .lastModifiedAt(comment.getLastModifiedAt())
-                            .isLiked(false)
+                            .isLiked(
+                                    comment.getCommentLikes().stream().map(
+                                            commentLike -> commentLike.getUser().getId()
+                                    ).collect(Collectors.toList()).contains(userId)
+                            )
                             .build();
         }
     }


### PR DESCRIPTION
삭제된 댓글에 좋아요표시가 되고 멀쩡한 댓글에는 표시가 안되도록 되어있었습니다ㅠㅠ
올바르게 바꿉니다.