### PR TITLE
Refactor : Transactional 수정

### DIFF
--- a/src/main/java/com/devillage/teamproject/service/comment/CommentServiceImpl.java
+++ b/src/main/java/com/devillage/teamproject/service/comment/CommentServiceImpl.java
@@ -20,7 +20,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 @Service
-@Transactional(readOnly = true)
+@Transactional
 @RequiredArgsConstructor
 public class CommentServiceImpl implements CommentService {
 
@@ -32,7 +32,6 @@ public class CommentServiceImpl implements CommentService {
     private final UserService userService;
 
     @Override
-    @Transactional
     public Comment createComment(Comment comment, String token) {
         User user = userService.findVerifiedUser(jwtTokenUtil.getUserId(token));
         Post post = postService.getPost(comment.getPost().getId());
@@ -40,12 +39,12 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Comment findComment() {
         return null;
     }
 
     @Override
-    @Transactional
     public Comment editComment(Long postId, Long commentId, String content) {
         Optional<Comment> optionalComment = commentRepository.findById(commentId);
 
@@ -63,7 +62,6 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
-    @Transactional
     public Comment likeComment(Long userId,Long postId, Long commentId) {
         User user = userService.findVerifiedUser(userId);
         Post post = postService.findVerifyPost(postId);
@@ -87,6 +85,7 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Page<Comment> findComments(Long postId, int page, int size) {
         postService.getPost(postId);
         Page<Comment> commentPage = commentRepository.findAllByPostId(postId, PageRequest.of(page, size));
@@ -100,7 +99,6 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
-    @Transactional
     public void deleteComment(Long commentId, String token) {
         Comment comment = findVerifiedComment(commentId);
         if (!Objects.equals(comment.getUser().getId(), jwtTokenUtil.getUserId(token))) {
@@ -115,7 +113,6 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
-    @Transactional
     public ReComment createReComment(ReComment reComment, String token) {
         Comment comment = findVerifiedComment(reComment.getComment().getId());
         User user = userService.findVerifiedUser(jwtTokenUtil.getUserId(token));
@@ -123,7 +120,6 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
-    @Transactional
     public ReComment editReComment(Long postId, Long commentId, Long reCommentId, String content) {
         Optional<ReComment> optionalReComment = reCommentRepository.findById(reCommentId);
 
@@ -142,12 +138,12 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<ReComment> findReComments() {
         return null;
     }
 
     @Override
-    @Transactional
     public void deleteReComment(Long postId, Long commentId, Long reCommentId) {
         Optional<ReComment> optionalReComment = reCommentRepository.findById(reCommentId);
 
@@ -164,6 +160,7 @@ public class CommentServiceImpl implements CommentService {
     }
 
 
+    @Transactional(readOnly = true)
     public Comment findVerifiedComment(Long commentId) {
         Optional<Comment> optionalComment = commentRepository.findById(commentId);
         return optionalComment.orElseThrow(() -> new BusinessLogicException(ExceptionCode.COMMENT_NOT_FOUND));

--- a/src/main/java/com/devillage/teamproject/service/file/LocalImageService.java
+++ b/src/main/java/com/devillage/teamproject/service/file/LocalImageService.java
@@ -24,7 +24,7 @@ import java.util.UUID;
  * https://owin2828.github.io/devlog/2020/01/09/etc-2.html
  */
 @Service
-@Transactional(readOnly = true)
+@Transactional
 @Slf4j
 public class LocalImageService implements FileService {
     private final FileRepository fileRepository;
@@ -36,7 +36,6 @@ public class LocalImageService implements FileService {
     }
 
     @Override
-    @Transactional
     public File saveFile(Long ownerUserId, MultipartFile multipartFile, StringBuffer requestURL) {
         User owner = userService.findVerifiedUser(ownerUserId);
         File file = parseMultipartFile(multipartFile, requestURL);
@@ -45,23 +44,23 @@ public class LocalImageService implements FileService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public File findFile(Long fileId) {
         return findVerifiedFile(fileId);
     }
 
     @Override
-    @Transactional
     public File editFile() {
         return null;
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<File> findFiles() {
         return null;
     }
 
     @Override
-    @Transactional
     public void deleteFile(Long fileId, Long userId) {
         File file = findVerifiedFile(fileId);
         if (!Objects.equals(file.getOwner().getId(), userId)) {
@@ -144,6 +143,7 @@ public class LocalImageService implements FileService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public File findFileWithFilename(String filename) {
         return fileRepository.findByFilename(filename).orElseThrow(
                 () -> new BusinessLogicException(ExceptionCode.FILE_NOT_FOUND)
@@ -151,6 +151,7 @@ public class LocalImageService implements FileService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public File findVerifiedFile(Long fileId) {
         return fileRepository.findById(fileId).orElseThrow(
                 () -> new BusinessLogicException(ExceptionCode.FILE_NOT_FOUND)

--- a/src/main/java/com/devillage/teamproject/service/user/UserServiceImpl.java
+++ b/src/main/java/com/devillage/teamproject/service/user/UserServiceImpl.java
@@ -24,7 +24,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @Service
-@Transactional(readOnly = true)
+@Transactional
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
 
@@ -35,18 +35,17 @@ public class UserServiceImpl implements UserService {
     private final PasswordEncoder passwordEncoder;
 
     @Override
-    @Transactional
     public User joinUser(User user) {
         return null;
     }
 
     @Override
+    @Transactional(readOnly = true)
     public User findUser(String token) {
         return findVerifiedUser(jwtTokenUtil.getUserId(token));
     }
 
     @Override
-    @Transactional
     public void editUser(Long userId, String nickName, String statusMessage) {
         Optional<User> optionalUser = userRepository.findById(userId);
 
@@ -71,14 +70,12 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    @Transactional
     public void deleteUser(String token) {
         User findUser = findVerifiedUser(jwtTokenUtil.getUserId(token));
         findUser.deleteUser();
     }
 
     @Override
-    @Transactional
     public Block blockUser(Long destUserId, String token) {
         Long srcUserId = jwtTokenUtil.getUserId(token);
         Optional<Block> optionalBlock = blockRepository.findBySrcUserIdAndDestUserId(srcUserId, destUserId);
@@ -109,6 +106,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public User findVerifiedUser(Long userId) {
         Optional<User> optionalUser = userRepository.findById(userId);
         User findUser = optionalUser.orElseThrow(() -> new BusinessLogicException(ExceptionCode.USER_NOT_FOUND));

--- a/src/test/java/com/devillage/teamproject/service/comment/CommentServiceTest.java
+++ b/src/test/java/com/devillage/teamproject/service/comment/CommentServiceTest.java
@@ -259,11 +259,11 @@ class CommentServiceTest implements Reflection {
 
         List<CommentLike> commentLikes = commentLikeRepository.findByCommentIdAndUserIdAndPostId(commentId,userId,postId);
 
-        given(jwtTokenUtil.getUserId(anyString())).willReturn(userId);
         given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
         given(commentLikeRepository.findByCommentIdAndUserIdAndPostId(anyLong(),anyLong(),anyLong())).willReturn(new ArrayList<>());
         given(userService.findVerifiedUser(userId)).willReturn(user);
         given(commentLikeRepository.countByCommentId(commentId)).willReturn(0L);
+        given(postService.findVerifyPost(postId)).willReturn(post);
 
         //when
         Comment compareComment = commentService.likeComment(userId,postId,commentId);


### PR DESCRIPTION
기존에는 클래스레벨에서 @Transactional(readOnly = true)가 적용되어있고 필요한 메서드에 @Transactional을 적용했으나,
클래스레벨에서 @Transactional을 하고 몇몇 읽기 메서드에서 @Transactional(readOnly = true)를 하는편이 에러방지 측면에서 더욱 나아보입니다.
EntityManager의 기능에 기대는 몇몇 기능의 경우(cascade 자동저장, 연관관계 자동저장, 변경감지 등) 아무리 단위테스트를 잘 짜도 SpringBootTest를
하지 않는 이상 해당 문제들을 잡아내지 못합니다. 그래서 더욱 이번 변경점이 필요해보입니다. 혹은 SpringBootTest를 몇가지 더하는것도 방법이겠습니다.